### PR TITLE
[mob][photos] Add compute controller cancellation for video streaming

### DIFF
--- a/mobile/apps/photos/lib/models/compute/cancel_token.dart
+++ b/mobile/apps/photos/lib/models/compute/cancel_token.dart
@@ -1,0 +1,37 @@
+/// Cancel token for managing compute operation cancellation
+class CancelToken {
+  bool _isCancelled = false;
+  final List<Function()> _onCancelCallbacks = [];
+
+  bool get isCancelled => _isCancelled;
+
+  void cancel() {
+    if (_isCancelled) return;
+
+    _isCancelled = true;
+
+    // Execute all registered callbacks
+    for (final callback in _onCancelCallbacks) {
+      try {
+        callback();
+      } catch (e) {
+        // Silently ignore callback errors
+      }
+    }
+    _onCancelCallbacks.clear();
+  }
+
+  void onCancel(Function() callback) {
+    if (_isCancelled) {
+      // If already cancelled, execute immediately
+      callback();
+    } else {
+      _onCancelCallbacks.add(callback);
+    }
+  }
+
+  void reset() {
+    _isCancelled = false;
+    _onCancelCallbacks.clear();
+  }
+}

--- a/mobile/apps/photos/lib/services/isolated_ffmpeg_service.dart
+++ b/mobile/apps/photos/lib/services/isolated_ffmpeg_service.dart
@@ -4,6 +4,7 @@ import "dart:isolate";
 import "package:ffmpeg_kit_flutter/ffmpeg_kit.dart";
 import "package:ffmpeg_kit_flutter/ffprobe_kit.dart";
 import "package:flutter/services.dart";
+import "package:logging/logging.dart";
 import "package:photos/utils/ffprobe_util.dart";
 
 class IsolatedFfmpegService {
@@ -12,9 +13,46 @@ class IsolatedFfmpegService {
   static final IsolatedFfmpegService instance =
       IsolatedFfmpegService._privateConstructor();
 
+  final _logger = Logger("IsolatedFfmpegService");
+  Isolate? _currentIsolate;
+
   Future<Map> runFfmpeg(String command) async {
     final rootIsolateToken = RootIsolateToken.instance!;
-    return await Isolate.run<Map>(() => _ffmpegRun(command, rootIsolateToken));
+
+    try {
+      // Store isolate reference for potential cancellation
+      final receivePort = ReceivePort();
+      _currentIsolate = await Isolate.spawn(
+        _ffmpegRunWithPort,
+        [command, rootIsolateToken, receivePort.sendPort],
+      );
+
+      // Wait for result
+      final result = await receivePort.first as Map;
+      _currentIsolate = null;
+      return result;
+    } catch (e) {
+      _currentIsolate = null;
+      rethrow;
+    }
+  }
+
+  /// Cancel all ongoing FFmpeg operations
+  void cancelAllOperations() {
+    _logger.info("Cancelling FFmpeg operations");
+
+    if (_currentIsolate != null) {
+      try {
+        _currentIsolate!.kill(priority: Isolate.immediate);
+        _currentIsolate = null;
+        _logger.info("FFmpeg isolate killed");
+      } catch (e) {
+        _logger.warning("Failed to kill FFmpeg isolate", e);
+      }
+    }
+
+    // Also cancel any active FFmpeg sessions globally
+    FFmpegKit.cancel();
   }
 
   Future<Map> getVideoInfo(String file) async {
@@ -51,4 +89,21 @@ Future<Map> _ffmpegRun(String value, RootIsolateToken rootIsolateToken) async {
     "returnCode": returnCode?.getValue(),
     "output": output,
   };
+}
+
+@pragma('vm:entry-point')
+Future<void> _ffmpegRunWithPort(List<dynamic> args) async {
+  final command = args[0] as String;
+  final rootIsolateToken = args[1] as RootIsolateToken;
+  final sendPort = args[2] as SendPort;
+
+  BackgroundIsolateBinaryMessenger.ensureInitialized(rootIsolateToken);
+  final session = await FFmpegKit.execute(command, true);
+  final returnCode = await session.getReturnCode();
+  final output = await session.getOutput();
+
+  sendPort.send({
+    "returnCode": returnCode?.getValue(),
+    "output": output,
+  });
 }

--- a/mobile/apps/photos/lib/services/machine_learning/compute_controller.dart
+++ b/mobile/apps/photos/lib/services/machine_learning/compute_controller.dart
@@ -8,6 +8,7 @@ import "package:flutter/foundation.dart";
 import "package:logging/logging.dart";
 import "package:photos/core/event_bus.dart";
 import "package:photos/events/compute_control_event.dart";
+import "package:photos/models/compute/cancel_token.dart";
 import "package:thermal/thermal.dart";
 
 enum ComputeRunState {
@@ -46,6 +47,12 @@ class ComputeController {
   bool _waitingToRunML = false;
 
   bool get isDeviceHealthy => _isDeviceHealthy;
+
+  /// Cancellation tokens for different compute types
+  final Map<ComputeRunState, CancelToken> _cancelTokens = {};
+
+  /// Callbacks to register for cleanup when compute is cancelled
+  final Map<ComputeRunState, Function?> _cleanupCallbacks = {};
 
   ComputeController() {
     _logger.info('ComputeController constructor');
@@ -97,6 +104,7 @@ class ComputeController {
     bool stream = false,
     bool bypassInteractionCheck = false,
     bool bypassMLWaiting = false,
+    Function? cleanupCallback,
   }) {
     _logger.info(
       "Requesting compute: ml: $ml, stream: $stream, bypassInteraction: $bypassInteractionCheck, bypassMLWaiting: $bypassMLWaiting",
@@ -116,8 +124,14 @@ class ComputeController {
     bool result = false;
     if (ml) {
       result = _requestML();
+      if (result && cleanupCallback != null) {
+        _cleanupCallbacks[ComputeRunState.runningML] = cleanupCallback;
+      }
     } else if (stream) {
       result = _requestStream(bypassMLWaiting);
+      if (result && cleanupCallback != null) {
+        _cleanupCallbacks[ComputeRunState.generatingStream] = cleanupCallback;
+      }
     } else {
       _logger.severe("No compute request specified, denying request.");
     }
@@ -132,6 +146,7 @@ class ComputeController {
     if (_currentRunState == ComputeRunState.idle) {
       _currentRunState = ComputeRunState.runningML;
       _waitingToRunML = false;
+      _cancelTokens[ComputeRunState.runningML] = CancelToken();
       _logger.info("ML request granted");
       return true;
     } else if (_currentRunState == ComputeRunState.runningML) {
@@ -149,6 +164,7 @@ class ComputeController {
         (bypassMLWaiting || !_waitingToRunML)) {
       _logger.info("Stream request granted");
       _currentRunState = ComputeRunState.generatingStream;
+      _cancelTokens[ComputeRunState.generatingStream] = CancelToken();
       return true;
     }
     _logger.info(
@@ -165,11 +181,15 @@ class ComputeController {
     if (ml) {
       if (_currentRunState == ComputeRunState.runningML) {
         _currentRunState = ComputeRunState.idle;
+        _cancelTokens.remove(ComputeRunState.runningML);
+        _cleanupCallbacks.remove(ComputeRunState.runningML);
       }
       _waitingToRunML = false;
     } else if (stream) {
       if (_currentRunState == ComputeRunState.generatingStream) {
         _currentRunState = ComputeRunState.idle;
+        _cancelTokens.remove(ComputeRunState.generatingStream);
+        _cleanupCallbacks.remove(ComputeRunState.generatingStream);
       }
     }
   }
@@ -213,6 +233,12 @@ class ComputeController {
       _logger.info(
         "Firing event: $shouldRunCompute      (device health: $_isDeviceHealthy, user interaction: $_isUserInteracting, mlInteractionOverride: $interactionOverride, blockers: $_computeBlocks)",
       );
+
+      // If compute should stop, cancel ongoing operations immediately
+      if (!shouldRunCompute) {
+        _cancelOngoingCompute();
+      }
+
       Bus.instance.fire(ComputeControlEvent(shouldRunCompute));
     }
   }
@@ -297,5 +323,40 @@ class ComputeController {
 
   bool _isBatteryHealthyAndroid() {
     return !kUnhealthyStates.contains(_androidLastBatteryInfo?.health ?? "");
+  }
+
+  void _cancelOngoingCompute() {
+    _logger.info("Cancelling ongoing compute operations");
+
+    // Cancel the current running task based on state
+    if (_currentRunState != ComputeRunState.idle) {
+      final cancelToken = _cancelTokens[_currentRunState];
+      if (cancelToken != null && !cancelToken.isCancelled) {
+        _logger.info("Cancelling $_currentRunState operations");
+        cancelToken.cancel();
+
+        // Execute cleanup callback if registered
+        final cleanupCallback = _cleanupCallbacks[_currentRunState];
+        if (cleanupCallback != null) {
+          _logger.info("Executing cleanup callback for $_currentRunState");
+          try {
+            cleanupCallback();
+          } catch (e, s) {
+            _logger.severe("Error during cleanup callback", e, s);
+          }
+        }
+      }
+    }
+  }
+
+  /// Get cancellation token for current compute state
+  CancelToken? getCancelToken() {
+    return _cancelTokens[_currentRunState];
+  }
+
+  /// Check if current compute operation has been cancelled
+  bool get isCancelled {
+    final token = _cancelTokens[_currentRunState];
+    return token?.isCancelled ?? false;
   }
 }

--- a/mobile/apps/photos/scripts/internal_changes.txt
+++ b/mobile/apps/photos/scripts/internal_changes.txt
@@ -1,3 +1,4 @@
+- Prateek: (i) Add compute controller cancellation for video streaming - quit immediately on poor device conditions
 - Neeraj: Simplify location display in file info - show "Location" title with "Add location" chip
 - Laurens: Fix edge case bug in similar images cache when user hasn't indexed ML yet
 - Neeraj: (i) Show shared albums in widget selection screen


### PR DESCRIPTION
## Description
- Implement immediate cancellation for video streaming when device conditions become unhealthy
- Add CancelToken mechanism for managing compute operation lifecycle
- Integrate cleanup handlers for proper resource release

## Changes
- Created `CancelToken` class for managing cancellation with callback support
- Enhanced `ComputeController` to automatically cancel operations when device overheats or battery is low
- Updated `VideoPreviewService` to check cancellation status and handle cleanup
- Modified `IsolatedFfmpegService` to support FFmpeg operation termination

## Tests
- [ ] Video streaming stops when device overheats
- [ ] Video streaming stops when battery drops below 20%
- [ ] Interrupted files are properly queued for retry
- [ ] FFmpeg operations are cleanly terminated
- [ ] Resources are properly released on cancellation
- [ ] Streaming resumes when device conditions improve